### PR TITLE
Add pytest tests for number utils

### DIFF
--- a/number_utils.py
+++ b/number_utils.py
@@ -403,40 +403,7 @@ def format_phone_number_for_speech(phone_number):
         # Return as-is if format is unclear
         return phone_number
 
-def test_number_conversions():
-    """Test function to verify number conversions work correctly."""
-    print("🧪 Testing number conversion utilities...")
-    
-    # Test word-to-number conversion
-    test_cases = [
-        "reservation number one two three four five six",
-        "seven eight nine zero one two",
-        "my number is five five five one two three four",
-        "reservation 123456"
-    ]
-    
-    print("\n📝 Word-to-number conversion tests:")
-    for test in test_cases:
-        converted = words_to_numbers(test)
-        extracted = extract_reservation_number_from_text(test)
-        print(f"  Input: '{test}'")
-        print(f"  Converted: '{converted}'")
-        print(f"  Extracted number: {extracted}")
-        print()
-    
-    # Test number-to-words conversion
-    response_tests = [
-        "I found your reservation for Jane Smith on 2025-06-11 at 8:00 PM for 2 people. Reservation number: 789012. Total bill: $89.00.",
-        "Your reservation number is 123456.",
-        "Call us at 555-1234 for assistance."
-    ]
-    
-    print("🔤 Number-to-words conversion tests:")
-    for test in response_tests:
-        converted = numbers_to_words(test)
-        print(f"  Original: '{test}'")
-        print(f"  For TTS: '{converted}'")
-        print()
-
 if __name__ == '__main__':
-    test_number_conversions() 
+    # Simple manual example when running this module directly
+    sample = "Your reservation number is 123456."
+    print(numbers_to_words(sample))

--- a/tests/test_number_utils.py
+++ b/tests/test_number_utils.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+import pytest
+
+# Ensure the repository root is on the path when tests are run directly
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from number_utils import words_to_numbers, numbers_to_words, extract_reservation_number_from_text
+
+
+def test_words_to_numbers_and_extraction():
+    cases = [
+        (
+            "reservation number one two three four five six",
+            "reservation number 1 2 3 4 5 6",
+            "123456",
+        ),
+        (
+            "seven eight nine zero one two",
+            "7 8 9 0 1 2",
+            "789012",
+        ),
+        (
+            "my number is five five five one two three four",
+            "my number is 5 5 5 1 2 3 4",
+            "555123",
+        ),
+        (
+            "reservation 123456",
+            "reservation 123456",
+            "123456",
+        ),
+    ]
+    for text, converted, expected in cases:
+        assert words_to_numbers(text) == converted
+        assert extract_reservation_number_from_text(text) == expected
+
+
+def test_numbers_to_words():
+    cases = [
+        (
+            "I found your reservation for Jane Smith on 2025-06-11 at 8:00 PM for 2 people. Reservation number: 789012. Total bill: $89.00.",
+            "I found your reservation for Jane Smith on 2025-06-11 at 8:00 PM for two people. Reservation number: seven eight nine zero one two. Total bill: $89.00.",
+        ),
+        (
+            "Your reservation number is 123456.",
+            "Your reservation number is one two three four five six.",
+        ),
+        (
+            "Call us at 555-1234 for assistance.",
+            "Call us at 555-1234 for assistance.",
+        ),
+    ]
+    for text, expected in cases:
+        assert numbers_to_words(text) == expected
+


### PR DESCRIPTION
## Summary
- remove inline number_utils test function
- add pytest-based test file for number utilities

## Testing
- `pytest tests/test_number_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c19e5cda4832a8cebbca68593bd3a