### PR TITLE
Fix trailing text in create_db.py

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -40,4 +40,4 @@ def create_database():
             traceback.print_exc()
 
 if __name__ == "__main__":
-    create_database() 
+    create_database()


### PR DESCRIPTION
## Summary
- remove stray end-of-file text in `create_db.py`
- ensure file ends with a newline

## Testing
- `pytest tests/test_number_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1bb56e90832aa0ea6daf44cba9e6