### PR TITLE
Fix venv activation path in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@ python -m venv venv
 
 # Activate virtual environment
 echo "Activating virtual environment..."
-source venv/Scripts/activate
+source venv/bin/activate
 
 # Install requirements with no cache
 echo "Installing requirements..."


### PR DESCRIPTION
## Summary
- ensure the startup script activates Python from `venv/bin`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685c1ce93d98832a9eb11e1fa8b9ae34